### PR TITLE
Add "Jessie" to Raspbian version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _We did it!_ It took a lot of head-banging and several indirect passings-of-the-
 
 **Note: These are unofficial binaries (though built from the minimally modified official source), and thus there is no expectation of support from the TensorFlow team. Please don't create issues for these files in the official TensorFlow repository.**
 
-This is the easiest way to get TensorFlow onto your Raspberry Pi 3. Note that currently, the pre-built binary is targeted for Raspberry Pi 3 running Raspbian 8.0, so this may or may not work for you.
+This is the easiest way to get TensorFlow onto your Raspberry Pi 3. Note that currently, the pre-built binary is targeted for Raspberry Pi 3 running Raspbian 8.0 ("Jessie"), so this may or may not work for you.
 
 First, install the dependencies for TensorFlow:
 


### PR DESCRIPTION
Hey Sam,
I just started out with the Raspberry Pi 3 and installed the newest Jessie OS. It took me some time to figure out what Raspbian 8.0 corresponded to, as for some reason most online sites just say "Jessie", so this might be helpful for future users.